### PR TITLE
[doc] substitue \@makeendtext with \@endnotetext

### DIFF
--- a/endnotes.sty
+++ b/endnotes.sty
@@ -169,7 +169,7 @@
 %   \makeenmark : A macro to generate the endnote marker from  \theenmark
 %                  The default definition is \hbox{$^\theenmark$}.
 %
-%   \@makeentext{NOTE} :
+%   \@endnotetext{NOTE} :
 %        Must produce the actual endnote, using \theenmark as the mark
 %        of the endnote and NOTE as the text.  It is called when effectively
 %        inside a \parbox, with \hsize = \columnwidth.  For example, it might

--- a/endnotes.tex
+++ b/endnotes.tex
@@ -190,7 +190,7 @@ by itself will work.)
 Endnotes use the following parameters, similar to those relating
 to footnotes:
 %
-\begin{labeling}[~:]{\cmd{\@makeentext}\marg{note}}
+\begin{labeling}[~:]{\cmd{\@endnotetext}\marg{note}}
   \item[\cmd{\enotesize}] Size-changing command for endnotes.
 
   \item[\cmd{\theendnote}] In usual \LaTeX\ style, produces the endnote number.
@@ -204,7 +204,7 @@ to footnotes:
   \item[\cmd{\makeenmark}] A macro to generate the endnote marker from  \cmd{\theenmark}.
     The default definition is \verb+\hbox{$^\theenmark$}+.
 
-  \item[\cmd{\@makeentext}\marg{note}]
+  \item[\cmd{\@endnotetext}\marg{note}]
     Must produce the actual endnote, using \cmd{\theenmark} as the mark
     of the endnote and \meta{note} as the text.  It is called when effectively
     inside a \cmd{\parbox}, with $\cmd{\hsize} = \cmd{\columnwidth}$.  For example, it might


### PR DESCRIPTION
This pr fixes a long-standing mistake in doc which can be traced back to 2016 (see this [answer on TeX-SX by egerg](https://tex.stackexchange.com/a/286359)): 
 - `\@makeendtext` is mentioned both in doc and in code comment but never defined.
 - It is `\@endnotetext` that plays the documented role of `\@makeendtext`.

Other notes: `\@makeendtext` has a more consistent naming scheme with latex2e's corresponding footnote macro `\@makefntext`, but I am afraid that renaming to `\@makeendtext` will break some documents in which `@endnotetext` was use (redefined).